### PR TITLE
Speed up the cypress GH action

### DIFF
--- a/.github/workflows/cypress-tests.yaml
+++ b/.github/workflows/cypress-tests.yaml
@@ -1,4 +1,4 @@
-name: Cypress Tests with installation job
+name: Run Cypress E2E tests
 
 on:
   push:
@@ -19,16 +19,6 @@ jobs:
         with:
           node-version: '14'
 
-      - name: Cache dependencies
-        uses: actions/cache@v2
-        with:
-          path: ~/.npm
-          key: npm-${{ hashFiles('package-lock.json') }}
-          restore-keys: npm-
-
-      - name: Install dependencies
-        run: npm ci --ignore-scripts
-
       - name: Install & Run Cypress tests
         uses: cypress-io/github-action@v2.9.7
         with:
@@ -39,38 +29,3 @@ jobs:
           wait-on-timeout: 120
           start: npm start
           config-file: ./cypress.config.ts
-
-      # - name: Save build folder
-      #   uses: actions/upload-artifact@v2
-      #   with:
-      #     name: build
-      #     if-no-files-found: error
-      #     path: dist
-
-  # run-chrome-tests:
-  #   runs-on: ubuntu-latest
-  #   container: cypress/browsers:node18.6.0-chrome105-ff104
-  #   needs: install
-  #   steps:
-  #     - name: Checkout
-  #       uses: actions/checkout@v2
-
-  #     - name: Download the build folders
-  #       uses: actions/download-artifact@v2
-  #       with:
-  #         name: build
-  #         path: dist
-
-  #     - name: Install serve
-  #       run: npm install serve
-
-  #     # Run all Cypress tests
-  #     - name: Cypress run
-  #       uses: cypress-io/github-action@v5.7.2
-  #       with:
-  #         browser: chrome
-  #         install: false
-  #         wait-on: 'http://localhost:8000'
-  #         wait-on-timeout: 120
-  #         start: npm start
-  #         config-file: ./cypress.config.ts

--- a/.github/workflows/cypress-tests.yaml
+++ b/.github/workflows/cypress-tests.yaml
@@ -7,14 +7,29 @@ on:
       - '!main' 
 
 jobs:
-  install:
+  cypress-tests-chrome:
     runs-on: ubuntu-latest
     container: cypress/browsers:node18.6.0-chrome105-ff104
     steps:
       - name: Checkout
         uses: actions/checkout@v2
 
-      - name: Cypress install
+      - name: Setup Node.js
+        uses: actions/setup-node@v2
+        with:
+          node-version: '14'
+
+      - name: Cache dependencies
+        uses: actions/cache@v2
+        with:
+          path: ~/.npm
+          key: npm-${{ hashFiles('package-lock.json') }}
+          restore-keys: npm-
+
+      - name: Install dependencies
+        run: npm ci --ignore-scripts
+
+      - name: Install & Run Cypress tests
         uses: cypress-io/github-action@v2.9.7
         with:
           # Disable running of tests within install job 

--- a/.github/workflows/cypress-tests.yaml
+++ b/.github/workflows/cypress-tests.yaml
@@ -18,40 +18,44 @@ jobs:
         uses: cypress-io/github-action@v2.9.7
         with:
           # Disable running of tests within install job 
-          runTests: false
           build: npm run build
-
-      - name: Save build folder
-        uses: actions/upload-artifact@v2
-        with:
-          name: build
-          if-no-files-found: error
-          path: dist
-
-  run-chrome-tests:
-    runs-on: ubuntu-latest
-    container: cypress/browsers:node18.6.0-chrome105-ff104
-    needs: install
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-
-      - name: Download the build folders
-        uses: actions/download-artifact@v2
-        with:
-          name: build
-          path: dist
-
-      - name: Install serve
-        run: npm install serve
-
-      # Run all Cypress tests
-      - name: Cypress run
-        uses: cypress-io/github-action@v5.7.2
-        with:
           browser: chrome
-          install: false
           wait-on: 'http://localhost:8000'
           wait-on-timeout: 120
           start: npm start
           config-file: ./cypress.config.ts
+
+      # - name: Save build folder
+      #   uses: actions/upload-artifact@v2
+      #   with:
+      #     name: build
+      #     if-no-files-found: error
+      #     path: dist
+
+  # run-chrome-tests:
+  #   runs-on: ubuntu-latest
+  #   container: cypress/browsers:node18.6.0-chrome105-ff104
+  #   needs: install
+  #   steps:
+  #     - name: Checkout
+  #       uses: actions/checkout@v2
+
+  #     - name: Download the build folders
+  #       uses: actions/download-artifact@v2
+  #       with:
+  #         name: build
+  #         path: dist
+
+  #     - name: Install serve
+  #       run: npm install serve
+
+  #     # Run all Cypress tests
+  #     - name: Cypress run
+  #       uses: cypress-io/github-action@v5.7.2
+  #       with:
+  #         browser: chrome
+  #         install: false
+  #         wait-on: 'http://localhost:8000'
+  #         wait-on-timeout: 120
+  #         start: npm start
+  #         config-file: ./cypress.config.ts

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "expect": "^27.5.1",
     "html-loader": "^3.1.0",
     "jest": "^27.5.1",
+    "jest-codemods": "^0.25.1",
     "jest-mock": "^27.5.1",
     "jsdom": "^19.0.0",
     "mock-local-storage": "^1.1.20",
@@ -55,7 +56,6 @@
   },
   "dependencies": {
     "cash-dom": "^8.1.0",
-    "jest-codemods": "^0.25.1",
     "lz-string": "^1.4.4",
     "serve": "^14.2.0"
   }


### PR DESCRIPTION
Having it take ~3m for a run that should already be cached shows that I'm doing something wrong.

Probably trying to manually handle caching. Looks like the Cypress action handles that internally.

Got the install & execution time down to ~1m 50s, which is ~60% speed increase.